### PR TITLE
Fixes two minor issues in Chapter 1

### DIFF
--- a/book_src/chapters/chapter1.do.txt
+++ b/book_src/chapters/chapter1.do.txt
@@ -309,7 +309,7 @@ class ForwardEuler_v0:
         """Compute solution for t_span[0] <= t <= t_span[1],
         using N steps."""
         t0, T = t_span
-        self.dt = T / N
+        self.dt = (T - t0) / N
         self.t = np.zeros(N + 1)  # N steps ~ N+1 time points
         self.u = np.zeros(N + 1)
 

--- a/book_src/chapters/chapter1.do.txt
+++ b/book_src/chapters/chapter1.do.txt
@@ -394,8 +394,8 @@ by systems of ODEs, i.e., multiple ODEs where the right-hand side of one equatio
 systems are also referred to as vector ODEs. One simple example is
 !bt
 \begin{alignat*}{2}
-u' &= v, \quad &&u(0) = 1\\
-v' &= -u, \quad &&v(0) = 0.
+u' &= -v, \quad &&u(0) = 1\\
+v' &=  u, \quad &&v(0) = 0.
 \end{alignat*}
 !et
 The solution of this system is $u=\cos t, v=\sin t$, which can easily be verified by inserting the solution into the equations


### PR DESCRIPTION
This PR fixes two minor issues in Chapter 1:

1. In the class `ForwardEuler_v0`, the time step size should be `dt = (T - t0)/N`  if the time interval is of the general
    form [t0, T] .
2. In addition, a sign error is fixed in Section 1.3.